### PR TITLE
Modified the broker and proxies to start making polling dinamic

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -148,12 +148,17 @@ func (ctx *BrokerContext) AddSnowflake(id string) *Snowflake {
 	return snowflake
 }
 
+func calculateNextPoll() string {
+	return "20"
+}
+
 /*
 For snowflake proxies to request a client from the Broker.
 */
 func proxyPolls(ctx *BrokerContext, w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("X-Session-ID")
 	body, err := ioutil.ReadAll(http.MaxBytesReader(w, r.Body, readLimit))
+	w.Header().Set("Snowflake-Next-Poll", calculateNextPoll())
 	if nil != err {
 		log.Println("Invalid data.")
 		w.WriteHeader(http.StatusBadRequest)

--- a/proxy-go/snowflake.go
+++ b/proxy-go/snowflake.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"strconv"
 
 	"git.torproject.org/pluggable-transports/snowflake.git/common/safelog"
 	"github.com/keroserene/go-webrtc"
@@ -26,7 +27,7 @@ import (
 const defaultBrokerURL = "https://snowflake-broker.bamsoftware.com/"
 const defaultRelayURL = "wss://snowflake.bamsoftware.com/"
 const defaultSTUNURL = "stun:stun.l.google.com:19302"
-const pollInterval = 5 * time.Second
+var pollInterval = 20 * time.Second
 
 //amount of time after sending an SDP answer before the proxy assumes the
 //client is not going to connect
@@ -171,6 +172,8 @@ func pollOffer(sid string) *webrtc.SessionDescription {
 			log.Printf("error polling broker: %s", err)
 		} else {
 			defer resp.Body.Close()
+			nextPoll, _ := strconv.Atoi(resp.Header.Get("Snowflake-Next-Poll"))
+			pollInterval = time.Duration(nextPoll) * time.Second
 			if resp.StatusCode != http.StatusOK {
 				log.Printf("broker returns: %d", resp.StatusCode)
 			} else {

--- a/proxy/broker.js
+++ b/proxy/broker.js
@@ -46,6 +46,7 @@ class Broker {
         if (xhr.DONE !== xhr.readyState) {
           return;
         }
+        snowflake.config.brokerPollInterval = xhr.getResponseHeader('Snowflake-Next-Poll') * 1000 || snowflake.config.brokerPollInterval;
         switch (xhr.status) {
           case Broker.STATUS.OK:
             return fulfill(xhr.responseText); // Should contain offer.

--- a/proxy/config.js
+++ b/proxy/config.js
@@ -20,7 +20,7 @@ Config.prototype.minRateLimit = 10 * 1024;
 
 Config.prototype.rateLimitHistory = 5.0;
 
-Config.prototype.defaultBrokerPollInterval = 20.0 * 1000;
+Config.prototype.brokerPollInterval = 20.0 * 1000;
 
 Config.prototype.maxNumClients = 1;
 

--- a/proxy/snowflake.js
+++ b/proxy/snowflake.js
@@ -52,7 +52,7 @@ class Snowflake {
     this.pollBroker();
     return this.pollInterval = setInterval((() => {
       return this.pollBroker();
-    }), this.config.defaultBrokerPollInterval);
+    }), this.config.brokerPollInterval);
   }
 
   // Regularly poll Broker for clients to serve until this snowflake is


### PR DESCRIPTION
Proxies were polling every 5 (proxy-go) and 20 (proxy) seconds each.
This changes make the broker tell the proxies how often to poll. Currently it's set to 20 sec but it's intended to be modified and dynamically adjust the polling rate as it's detailed in ticket #25598.